### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "Math::FourierTransform",
+    "license" : "Artistic-2.0",
     "version" : "0.0.1",
     "description" : "Discrete Fourier Transform implementation.",
     "author" : "Matt Oates",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license